### PR TITLE
fix: to prevent possible error during `initdb`

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -707,7 +707,7 @@ install_custom_env() {
 
 	if [[ -f ./custom/customPostgresql.conf ]]; then
 		echo "--> Found customPostgresql.conf; overriding default 'postgresql.conf'"
-		sed -i -e 's|{{ POSTGRES_CONF }}|./customPostgresql.conf:/var/lib/postgresql/data/postgresql.conf|g' ./live/docker-compose.yml
+		sed -i -e 's|{{ POSTGRES_CONF }}|./customPostgresql.conf:/etc/postgresql.conf|g' ./live/docker-compose.yml
 		cp ./custom/customPostgresql.conf ./live
 	else
 		sed -i '/{{ POSTGRES_CONF }}/d' ./live/docker-compose.yml

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-LED_CURRENT_VERSION="1.3.2"
+LED_CURRENT_VERSION="1.3.3"
 
 # cd to the directory the script is in
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)

--- a/templates/docker-compose.yml.template
+++ b/templates/docker-compose.yml.template
@@ -50,7 +50,7 @@ services:
     logging: *default-logging
 
   pictrs:
-    image: asonix/pictrs:0.4.3
+    image: asonix/pictrs:0.4.7
     user: 991:991
     environment:
       - PICTRS__MEDIA__VIDEO_CODEC=vp9


### PR DESCRIPTION
When use customized pg configuration file, it would be better to mount it to `/etc/postgresql.conf` instead.

Or it maybe partially overlap the `/var/lib/postgresql/data` directory[^1], which can cause the check during `initdb` failed.

Below is the truncated ouput:

```
--> Found customPostgresql.conf; overriding default 'postgresql.conf'
[+] Pulling 5/5
 ✔ pictrs Pulled                                                                                                                                                                                            4.9s 
 ✔ proxy Pulled                                                                                                                                                                                             4.6s 
 ✔ postgres Pulled                                                                                                                                                                                          4.0s 
 ✔ lemmy Pulled                                                                                                                                                                                             1.8s 
 ✔ lemmy-ui Pulled                                                                                                                                                                                          2.8s 
[+] Running 5/7
 ⠸ Network lemmy-easy-deploy_default         Created                                                                                                                                                        2.3s 
 ⠸ Volume "lemmy-easy-deploy_postgres_data"  Created                                                                                                                                                        2.2s 
 ✔ Container lemmy-easy-deploy-pictrs-1      Started                                                                                                                                                        0.7s 
 ✔ Container lemmy-easy-deploy-postgres-1    Started                                                                                                                                                        0.8s 
 ✔ Container lemmy-easy-deploy-lemmy-1       Started                                                                                                                                                        1.1s 
 ✔ Container lemmy-easy-deploy-lemmy-ui-1    Started                                                                                                                                                        1.4s 
 ✔ Container lemmy-easy-deploy-proxy-1       Started                                                                                                                                                        2.1s 

Checking deployment status...
Checking proxy... OK!
Checking lemmy... OK!
Checking lemmy-ui... OK!
Checking pictrs... OK!
Checking postgres... restarting ... FAILED

ERROR: Service postgres unhealthy. Deployment failed.
Dumping logs... 

Logs dumped to: ./failure-1718375690.log
(DO NOT POST THESE LOGS PUBLICLY, THEY MAY CONTAIN SENSITIVE INFORMATION)

Please check these logs for potential easy fixes before reporting an issue!

Shutting down failed deployment...
[+] Running 6/6
 ✔ Container lemmy-easy-deploy-proxy-1     Removed                                                                                                                                                          0.3s 
 ✔ Container lemmy-easy-deploy-lemmy-ui-1  Removed                                                                                                                                                          0.2s 
 ✔ Container lemmy-easy-deploy-lemmy-1     Removed                                                                                                                                                          0.0s 
 ✔ Container lemmy-easy-deploy-postgres-1  Removed                                                                                                                                                          0.0s 
 ✔ Container lemmy-easy-deploy-pictrs-1    Removed                                                                                                                                                          0.5s 
 ✔ Network lemmy-easy-deploy_default       Removed
```

And the related content of `failure-xxx.log`: 

```
postgres-1  | initdb: error: directory "/var/lib/postgresql/data" exists but is not empty
postgres-1  | initdb: hint: If you want to create a new database system, either remove or empty the directory "/var/lib/postgresql/data" or run initdb with an argument other than "/var/lib/postgresql/data".
postgres-1  | The files belonging to this database system will be owned by user "postgres".
postgres-1  | This user must also own the server process.
```

Finally the result of `./deploy.sh -d`:

```
==== Docker Information ====
Detected runtime: docker (Docker version 25.0.3, build 4debf41)
Detected compose: docker compose (Docker Compose version v2.24.6)
   Runtime state: OK

==== System Information ====
      OS: Linux
  KERNEL: 5.15.0-94-generic (x86_64)
HOSTNAME: OK
   SHELL: bash
  MEMORY:
               total        used        free      shared  buff/cache   available
Mem:           7.3Gi       2.0Gi       496Mi        73Mi       4.7Gi       4.8Gi
Swap:             0B          0B          0B

DISTRO:
----------------------------
PRETTY_NAME="Ubuntu 22.04 LTS"
NAME="Ubuntu"
VERSION_CODENAME=jammy
UBUNTU_CODENAME=jammy
----------------------------

==== Lemmy-Easy-Deploy Information ====
Version: 1.3.4

IMAGE     CREATED   STATUS

Integrity:
    b4e3e486885dd2cc3a906f5421501c5c8e21dd1d7d94a78bc9d3ed21ac7f5c96  ./deploy.sh
    92c95dfc886792b8df2e9fffb540fc71a35c3bc6fd6c7662134da1545a79457a  ./templates/Caddy-Dockerfile.template
    c1202e70662dd2228da36a35a0f38ec8fc81bec8964d7315d02e8671a58dd7d7  ./templates/Caddyfile.template
    2537678c7971df36c1ed95f4228d3cfcb15bb4a28a60d939eaf8dd75b5d64a36  ./templates/cloudflare.snip
    c9cb4c5fee12930e17798a02ae1bd12e2dc69e149a394c24511bc9d4e6b776d4  ./templates/compose-email.snip
    c494a610bcb4cd1cfc0a4fe4fb0f6d437b2a84a0ad1625daee240e6dd6f1c910  ./templates/compose-email-volumes.snip
    09b990908d667411c9089b6848cf63d30ad3e76b1e560747833c3cc241ab95a4  ./templates/docker-compose.yml.template
    1c202b1b6e87c65b2fcda6035c9fe3f8631d76662907ffd38f24b14686e30647  ./templates/lemmy-email.snip
    c834cdce9eaf77f38155b404724fdfe66845575386ee516987452aa715642a6f  ./templates/lemmy.hjson.template

Custom Files: 
total 4.0K
-rw-rw-r-- 1 1000 1000 408 Jun 14 17:14 customPostgresql.conf

==== Settings ====
        CLOUDFLARE: No
 CADDY_DISABLE_TLS: false
   CADDY_HTTP_PORT: 80
  CADDY_HTTPS_PORT: 443
 LEMMY_TLS_ENABLED: true
      ENABLE_EMAIL: false
         SMTP_PORT: 25
    ENABLE_POSTFIX: false
POSTGRES_POOL_SIZE: 5

==== Generated Files ====
Deploy Version: (not deployed)

total 40K
drwxrwxr-x 2 1000 1000 4.0K Jun 14 22:34 caddy
-rw-rw-r-- 1 1000 1000   35 Jun 14 22:34 caddy.env
-rw-rw-r-- 1   70 1000  408 Jun 14 22:34 customPostgresql.conf
-rw-rw-r-- 1 1000 1000 1.8K Jun 14 22:34 docker-compose.yml
-rw-rw-r-- 1 1000 1000   50 Jun 14 22:34 lemmy.env
-rw-rw-r-- 1 1000 1000  482 Jun 14 22:34 lemmy.hjson
drwxr-xr-x 2    0    0 4.0K Jun 14 22:34 lemmy-ui-themes
-rw-rw-r-- 1 1000 1000   49 Jun 14 22:34 pictrs.env
-rw-rw-r-- 1 1000 1000   39 Jun 14 22:34 postfix.env
-rw-rw-r-- 1 1000 1000   51 Jun 14 22:34 postgres.env
```

Mounting to `/etc/postgresql.conf` solves this problem.

[^1]: https://stackoverflow.com/a/70079671/8073702